### PR TITLE
Tweak visuals CSV cleaning for `descriptive-analytics`

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,24 +92,20 @@ Any changes to the entrypoint definition or function implementing the entrypoint
 * `descriptive-analytics` - generates analytics outputs from a given project source folder and saving them to local folder (within the project folder), e.g. for the Dengue synthetic demo project
 ```shell
 $ descriptive-analytics demo-projects/ARChetypeCRF_dengue_synthetic/
-2026-03-20 12:16:23 [INFO] vertex.descriptive_analytics: Loading project data from project path: "/Users/smurthy/Documents/srm/dev/VERTEX/demo-projects/ARChetypeCRF_dengue_synthetic"
-2026-03-20 12:16:25 [INFO] vertex.io: Retrieving data from redcap API
-2026-03-20 12:16:26 [INFO] vertex.getREDCapData: REDCap data pipeline start
-2026-03-20 12:16:26 [INFO] vertex.getREDCapData: REDCap records export: requesting all records
-2026-03-20 12:16:30 [INFO] vertex.getREDCapData: REDCap records export complete in 3.9s (rows=6495)
-2026-03-20 12:16:30 [INFO] vertex.getREDCapData: REDCap step get_records finished in 3.9s
-2026-03-20 12:16:30 [INFO] vertex.getREDCapData: REDCap step get_data_dictionary finished in 0.2s
-2026-03-20 12:16:30 [INFO] vertex.getREDCapData: REDCap step get_missing_data_codes finished in 0.2s
-2026-03-20 12:16:32 [INFO] vertex.getREDCapData: REDCap step initial_data_processing finished in 2.3s (rows=6495, cols=685)
-2026-03-20 12:16:33 [INFO] vertex.getREDCapData: REDCap step get_form_event finished in 0.5s
-2026-03-20 12:16:33 [INFO] vertex.getREDCapData: REDCap step get_df_map finished in 0.1s (rows=1000)
-2026-03-20 12:16:33 [INFO] vertex.getREDCapData: REDCap step get_df_forms finished in 0.0s (forms=4)
-2026-03-20 12:16:33 [INFO] vertex.getREDCapData: REDCap data pipeline complete in 7.3s
-2026-03-20 12:16:33 [INFO] vertex.descriptive_analytics: Saving outputs to "/Users/smurthy/Documents/srm/dev/VERTEX/demo-projects/ARChetypeCRF_dengue_synthetic/outputs"
-2026-03-20 12:16:33 [WARNING] vertex.io: Folder "/Users/smurthy/Documents/srm/dev/VERTEX/demo-projects/ARChetypeCRF_dengue_synthetic/outputs/" already exists, removing this
-2026-03-20 12:16:33 [INFO] vertex.io: Saving files for static dashboard to "/Users/smurthy/Documents/srm/dev/VERTEX/demo-projects/ARChetypeCRF_dengue_synthetic/outputs/"
-2026-03-20 12:16:43 [INFO] vertex.io: Public dashboard files saved to /Users/smurthy/Documents/srm/dev/VERTEX/demo-projects/ARChetypeCRF_dengue_synthetic/outputs/
+2026-03-26 10:00:05 [INFO] vertex.descriptive_analytics: Loading project data from project path: "/Users/smurthy/Documents/srm/dev/VERTEX/demo-projects/ARChetypeCRF_dengue_synthetic"
+2026-03-26 10:00:13 [INFO] vertex.io: Retrieving data from redcap API
+...
+2026-03-26 10:00:24 [INFO] vertex.descriptive_analytics: Saving outputs to "/Users/smurthy/Documents/srm/dev/VERTEX/demo-projects/ARChetypeCRF_dengue_synthetic/outputs"
+...
+2026-03-26 10:00:38 [INFO] vertex.descriptive_analytics: Saving insight panel figures to "/Users/smurthy/Documents/srm/dev/VERTEX/demo-projects/ARChetypeCRF_dengue_synthetic/outputs"
+...
+2026-03-26 10:03:20 [INFO] vertex.io: Cleaning figure table CSVs
+2026-03-26 10:03:20 [INFO] vertex.io: Cleaning figure table CSV /Users/smurthy/Documents/srm/dev/VERTEX/demo-projects/ARChetypeCRF_dengue_synthetic/outputs/visuals/outcomes_complications/fig_table_data___0.csv
 ```
+
+> [!Note]
+The `descriptive-analytics` tool requires Google Chrome to be installed as some Chrome imaging functionality is used by the [kaleido](https://plotly.com/python/static-image-export/#kaleido) dependency when exporting/saving
+images - see [https://plotly.com/python/static-image-export/] for further information.
 
 ## Contributors
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -346,3 +346,30 @@ def test_load_project_data_analysis_without_insight_panels_path_should_remain_an
 
     # Desired behavior once hardened:
     assert loaded["mode"] == "analysis"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (-1, -1),
+        (True, True),
+        ("<b>Value</b>", "Value"),
+        ("<b><i>Value</i></b>", "Value"),
+    ],
+)
+def test_strip_html(value, expected):
+    assert vertex_io.strip_html(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (-1, -1),
+        (True, True),
+        ("<b>Value</b>", "<b>Value</b>"),
+        ("<b><i>Value</i></b>", "<b><i>Value</i></b>"),
+        ("↳ Value", " Value"),
+    ],
+)
+def test_strip_nonstandard_unicode_chars(value, expected):
+    assert vertex_io.strip_nonstandard_unicode_chars(value) == expected

--- a/vertex/io.py
+++ b/vertex/io.py
@@ -626,7 +626,7 @@ def copy_figure_table_csvs(source_path: str | Path, target_path: str | Path) -> 
 
 
 def strip_html(value: typing.Any) -> str | typing.Any:
-    """:py:class:`typing.Any` : Strip HTML elements from a string value, otherwise return the original value.
+    """:py:class:`typing.Any` : Strip HTML elements from a value.
 
     Parameters
     ----------
@@ -641,6 +641,33 @@ def strip_html(value: typing.Any) -> str | typing.Any:
     """
     if isinstance(value, str):
         return re.sub(r"<.*?>", "", value)
+
+    return value
+
+
+def strip_nonstandard_unicode_chars(value: typing.Any) -> str | typing.Any:
+    """:py:class:`typing.Any` : Strip any non-standard (usually, non-alphabetic) Unicode characters from a value.
+
+    The non-standard Unicode characters of interest are defined within the
+    function itself, and are currently limited to the "↳" (U+21B3) character,
+    but may be extended to include other characters.
+
+    Parameters
+    ----------
+    value : typing.Any
+        A value.
+
+    Returns
+    -------
+    str, typing.Any
+        Either a string stripped of all non-standard Unicode characters, or the
+        original non- string value.
+    """
+    nonstandard_unicode_chars = "↳"
+
+    if isinstance(value, str):
+        return re.sub(rf"[{nonstandard_unicode_chars}]", "", value)
+
     return value
 
 
@@ -648,9 +675,9 @@ def clean_figure_table(figure_table: pd.DataFrame) -> pd.DataFrame:
     """:py:class:pandas.DataFrame : A cleaned figure table dataframe.
 
     The cleaning steps are unique to the Plotly graph object table format from
-    which the table CSVs were originally, which contains HTML styling elements,
-    the cleaning is essentially the removal of these HTML elements to create
-    a plaintext CSV of the original.
+    which the table CSVs were originally, which contain HTML styling elements
+    and non-standard (non-alphabetic) Unicode characters. The cleaning is the
+    removal of such characters.
 
     Parameters
     ----------
@@ -665,5 +692,6 @@ def clean_figure_table(figure_table: pd.DataFrame) -> pd.DataFrame:
     # The use of `pandas.DataFrame.map` here is not absolutely optimal, as
     # `map` applies changes across the dataframe element-wise, but is the
     # safer choice given that the dataframe may contain a number of non-string
-    # columns, while the cleaning steps currently only apply to string values.
-    return figure_table.map(strip_html)
+    # columns which cannot be known in advance, while the cleaning steps
+    # currently only apply to string values.
+    return figure_table.map(strip_html).map(strip_nonstandard_unicode_chars)


### PR DESCRIPTION
* Further cleaning steps for the figure table CSVs when they are exported to the `visuals` outputs subfolder
* Update README
* Update vertex IO unit tests