### PR TITLE
Add compatibility shims for legacy imports

### DIFF
--- a/tests/unit/test_legacy_module_shims.py
+++ b/tests/unit/test_legacy_module_shims.py
@@ -1,0 +1,23 @@
+import importlib
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("legacy_module", "target_module", "exported_name"),
+    [
+        ("vertex.IsaricAnalytics", "IsaricAnalytics", "descriptive_table"),
+        ("vertex.IsaricDraw", "IsaricDraw", "fig_text"),
+        ("vertex.getREDCapData", "getREDCapData", "get_records"),
+    ],
+)
+def test_legacy_vertex_module_shims_warn_and_reexport(monkeypatch, legacy_module, target_module, exported_name):
+    target = importlib.import_module(f"isaricanalytics.{target_module}")
+    monkeypatch.delitem(sys.modules, legacy_module, raising=False)
+
+    namespace = {}
+    with pytest.warns(DeprecationWarning, match=legacy_module):
+        exec(f"from {legacy_module} import *", namespace, namespace)
+
+    assert namespace[exported_name] is getattr(target, exported_name)

--- a/vertex/IsaricAnalytics.py
+++ b/vertex/IsaricAnalytics.py
@@ -1,0 +1,11 @@
+"""Deprecated compatibility shim for legacy ``vertex.IsaricAnalytics`` imports."""
+
+import warnings as _warnings
+
+_warnings.warn(
+    "vertex.IsaricAnalytics is deprecated; import from isaricanalytics.IsaricAnalytics instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+from isaricanalytics.IsaricAnalytics import *  # noqa: F401,F403,E402

--- a/vertex/IsaricDraw.py
+++ b/vertex/IsaricDraw.py
@@ -1,0 +1,11 @@
+"""Deprecated compatibility shim for legacy ``vertex.IsaricDraw`` imports."""
+
+import warnings as _warnings
+
+_warnings.warn(
+    "vertex.IsaricDraw is deprecated; import from isaricanalytics.IsaricDraw instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+from isaricanalytics.IsaricDraw import *  # noqa: F401,F403,E402

--- a/vertex/getREDCapData.py
+++ b/vertex/getREDCapData.py
@@ -1,0 +1,11 @@
+"""Deprecated compatibility shim for legacy ``vertex.getREDCapData`` imports."""
+
+import warnings as _warnings
+
+_warnings.warn(
+    "vertex.getREDCapData is deprecated; import from isaricanalytics.getREDCapData instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+from isaricanalytics.getREDCapData import *  # noqa: F401,F403,E402


### PR DESCRIPTION
Existing project's insight_panels will no longer be compatible with VERTEX due to old imports.