### PR TITLE
Prevent resize jitter on first render of a figure pane

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -2,3 +2,31 @@
     max-width: 95% !important; /* allows the modal to be wider */
     width: 95% !important; /* sets a specific width */
 }
+
+/* Keep modal body scroll behavior stable across first render. */
+#modal .modal-body {
+    overflow-y: auto !important;
+    scrollbar-gutter: stable;
+}
+
+/*
+NOTE(ADW): This gorgeous piece of CSS will keep tab panes measurable for Plotly even when inactive.
+Bootstrap hides inactive panes with display:none, which makes first render jump when the pane is shown.
+This keeps panes in layout while only the active one is visible.
+*/
+#modal .tab-content {
+    position: relative;
+}
+
+#modal .tab-content > .tab-pane {
+    display: block;
+    visibility: hidden;
+    height: 0;
+    overflow: hidden;
+}
+
+#modal .tab-content > .active {
+    visibility: visible;
+    height: auto;
+    overflow: visible;
+}

--- a/vertex/layout/modals.py
+++ b/vertex/layout/modals.py
@@ -17,9 +17,17 @@ def create_modal(visuals, button, filter_options=None):
         insight_children = []
         about_str = ""
     else:
+        # NOTE(ADW): We keep all tab panes layout-measurable via CSS in assets/style.css.
+        # This prevents plotly resize jumps when inactive tabs become visible.
         insight_children = [
             dbc.Tabs(
-                [dbc.Tab(dbc.Row([dbc.Col(dcc.Graph(figure=figure), id=id)]), label=label) for figure, id, label, _ in visuals],
+                [
+                    dbc.Tab(
+                        dbc.Row([dbc.Col(dcc.Graph(figure=figure, style={"width": "100%", "height": "100%"}), id=id)]),
+                        label=label,
+                    )
+                    for figure, id, label, _ in visuals
+                ],
                 active_tab="tab-0",
             )
         ]


### PR DESCRIPTION
… the pane size before first render and prevent jitter on resize


I didnt think this would be easy, had to approach the problem from another way,

Existing:
<img width="3676" height="1763" alt="vertex_jitter" src="https://github.com/user-attachments/assets/27ae25d6-6e64-4960-bac6-0d9c6862f69e" />

New:
<img width="3675" height="1763" alt="vertex_no_jitter" src="https://github.com/user-attachments/assets/177050b2-e6dd-41eb-ad1a-94c226880fe8" />

The issue is that boostrap is hiding panes, sensibly, with display: none, this means plotly can not possibly know the size of the pane when rendering the figure so we are simultaneously rendering the pane and the figure and then re-rendering as if on resize causing jitter.

The solution is to override dash/dbc display behaviour and instead hide the pane with visibility:none instead, this way the pane is already in the DOM and plotly can correctly render the figure at the right size first pass