### PR TITLE
Prevent codecov patch diff fails on main

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,6 +12,8 @@ coverage:
         threshold: 1%
     patch:
       default:
+        # Enforce patch coverage on PRs, but do not fail direct commits on main.
+        only_pulls: true
         target: 20%
 
 ignore:


### PR DESCRIPTION
currently codecov fails main due to patch-diff requirements, this should be prs only.